### PR TITLE
Cleanup logging

### DIFF
--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -59,13 +59,14 @@ module Cacheable
     def cacheable_info_dump
       # This should come from nginx
       suggested_key = @env.has_key?('HTTP_X_CACHEABLE_KEY') ? "#{@env['HTTP_X_CACHEABLE_KEY']} (#{@env['HTTP_X_CACHEABLE_SIGNATURE']})" : nil
-      [
-        "Browser gzip: #{@env['gzip']}",
-        "Suggested key: #{suggested_key}",
+
+      log_info = [
         "Raw cacheable.key: #{versioned_key}",
         "cacheable.key: #{versioned_key_hash}",
-        "If-None-Match: #{@env['HTTP_IF_NONE_MATCH']}"
-      ].join(", ")
+      ]
+      log_info.push("Suggested key: #{suggested_key}") if suggested_key
+      log_info.push("If-None-Match: #{@env['HTTP_IF_NONE_MATCH']}") if @env['HTTP_IF_NONE_MATCH']
+      log_info.join(", ")
     end
 
     def try_to_serve_from_cache

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -57,14 +57,10 @@ module Cacheable
     end
 
     def cacheable_info_dump
-      # This should come from nginx
-      suggested_key = @env.has_key?('HTTP_X_CACHEABLE_KEY') ? "#{@env['HTTP_X_CACHEABLE_KEY']} (#{@env['HTTP_X_CACHEABLE_SIGNATURE']})" : nil
-
       log_info = [
         "Raw cacheable.key: #{versioned_key}",
         "cacheable.key: #{versioned_key_hash}",
       ]
-      log_info.push("Suggested key: #{suggested_key}") if suggested_key
       log_info.push("If-None-Match: #{@env['HTTP_IF_NONE_MATCH']}") if @env['HTTP_IF_NONE_MATCH']
       log_info.join(", ")
     end

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -61,8 +61,10 @@ module Cacheable
         "Raw cacheable.key: #{versioned_key}",
         "cacheable.key: #{versioned_key_hash}",
       ]
-      log_info.push("If-None-Match: #{@env['HTTP_IF_NONE_MATCH']}") if @env['HTTP_IF_NONE_MATCH']
-      log_info.join(", ")
+      if @env['HTTP_IF_NONE_MATCH']
+        log_info.push("If-None-Match: #{@env['HTTP_IF_NONE_MATCH']}")
+      end
+      log_info.join(', ')
     end
 
     def try_to_serve_from_cache


### PR DESCRIPTION
Looking through the logs in splunk, the cacheable gem logs a line like this for every request:

```
[Cacheable] Browser gzip: false, Suggested key: , Raw cacheable.key: 8506570,false,text/html,www.shopwestindieswear.com,/,,,false,,,:7700401694961521622, cacheable.key: cacheable:618e467be6a84698402813bd6ebb718f, If-None-Match: 
```

Now, "Browser gzip" is useless information -- it's usually true, and when it's not, a separate line is logged that looks like this:

```
[Cacheable] uncompressing for client without gzip
```

"Suggested key" and "If-None-Match:" are almost always nil, so I made them conditional. 

r: @csfrancis 
