### PR TITLE
Clear memoized cache_store when writing new value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.3.1

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -7,6 +7,7 @@ require 'msgpack'
 module Cacheable
 
   def self.cache_store=(store)
+    @cache_store = nil
     @store=store
   end
 


### PR DESCRIPTION
Currently, `Cacheable` will not clear the `@cache_store` instance variable. Which means that updating that value at runtime will not actually change anything. 

By clearing `@cache_store` the next call to `#cache_store` will recompute the value of the cache store.

@fw42 @Sirupsen 