### PR TITLE
Break reliance on specific Shopify middleware by using a standard middleware

### DIFF
--- a/lib/cacheable/railtie.rb
+++ b/lib/cacheable/railtie.rb
@@ -2,7 +2,7 @@ module Cacheable
 
   class Railtie < ::Rails::Railtie
     initializer "cachable.configure_active_record" do |config|
-      config.middleware.insert_before 'FixBadAcceptHeader', Cacheable::Middleware
+      config.middleware.insert_after Rack::Head, Cacheable::Middleware
       ActionController::Base.send(:include, Cacheable::Controller)
 
       ActiveRecord::Base.class_eval do


### PR DESCRIPTION
As part of upgrading to rails 5, I want to break this gem's coupling with the shopify specific middleware. This was also attempted in #19 but I guess didn't end up being needed. 

This will help with Shopify/shopify#90423

Either the solution in #19 or this one works for me.

@Shopify/rails5 

cc @csfrancis @cjoudrey 

Note: this will change the middleware ordering, so I'll test this thoroughly. Doesn't look like a problem just from looking at the code though.