### PR TITLE
Avoid parsing the user agent when it is not required

### DIFF
--- a/lib/cacheable/middleware.rb
+++ b/lib/cacheable/middleware.rb
@@ -67,10 +67,16 @@ module Cacheable
       Time.now.to_i
     end
 
+    REQUESTED_WITH = "HTTP_X_REQUESTED_WITH".freeze
+    ACCEPT = "HTTP_ACCEPT".freeze
+    USER_AGENT = "HTTP_USER_AGENT".freeze
     def ie_ajax_request?(env)
-      return false unless env["HTTP_USER_AGENT"].present? && (env["HTTP_X_REQUESTED_WITH"].present? || env["HTTP_ACCEPT"].present?)
-      agent = UserAgent.parse(env["HTTP_USER_AGENT"])
-      agent.browser == "Internet Explorer" && (env["HTTP_X_REQUESTED_WITH"] == "XmlHttpRequest" || env["HTTP_ACCEPT"] == "application/json")
+      return false unless env[USER_AGENT].present?
+      if env[REQUESTED_WITH] == "XmlHttpRequest".freeze || env[ACCEPT] == "application/json".freeze
+        UserAgent.parse(env["HTTP_USER_AGENT"]).is_a?(UserAgent::Browsers::InternetExplorer)
+      else
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
I saw `useragent` show up in profiles. Not by a huge amount but I was intrigued:

```
ok: run: /etc/sv/borg-shopify-unicorn-1/: (pid 17214) 33s
Profile Stats:
==================================
  Mode: cpu(1000)
  Samples: 143 (29.90% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
         3   (2.1%)           1   (0.7%)     UserAgent::Browsers::Webkit.extend?

Raw stackprof dump file: https://shopify-profile.s3.amazonaws.com/1484913558_sb1.ash.shopifydc.com_stackprof.dump
```

Looking at `useragent`source, parsing seems quite expensive, but I couldn't find any improvements.

But looking at the caller, it appears that there is many conditions that are quite likely to be true that would allow us to return false without parsing the user agent.

This PR simply check them first.

@mcgain @xldenis (you guys were last to touch that repo so it's now yours 😉 )