### PR TITLE
Fix for Rails 5.1 on `render: text`:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: ruby
 rvm:
   - 2.3.1
+gemfile:
+- gemfiles/actionpack-4-0.gemfile
+- gemfiles/actionpack-5-0.gemfile

--- a/cacheable.gemspec
+++ b/cacheable.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails", ">= 4.2"
 
   s.add_runtime_dependency "activesupport"
-  s.add_runtime_dependency "actionpack", ">= 3.2.17"
+  s.add_runtime_dependency "actionpack", ">= 4.1"
   s.add_runtime_dependency "useragent"
   s.add_runtime_dependency "msgpack"
 end

--- a/gemfiles/actionpack-4-0.gemfile
+++ b/gemfiles/actionpack-4-0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'actionpack', '~> 4.0'

--- a/gemfiles/actionpack-5-0.gemfile
+++ b/gemfiles/actionpack-5-0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem 'actionpack', '~> 5.0'

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -140,7 +140,7 @@ module Cacheable
               body = Cacheable.decompress(body)
             end
 
-            render text: body, status: status
+            render plain: body, status: status
           end
         end
       end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -43,7 +43,7 @@ class ResponseCacheHandlerTest < MiniTest::Unit::TestCase
 
   def test_client_cache_hit
     controller.request.env['HTTP_IF_NONE_MATCH'] = handler.versioned_key_hash
-    controller.expects(:head).with(:not_modified) 
+    controller.expects(:head).with(:not_modified)
     handler.run!
     assert_env(false, 'client')
   end
@@ -141,14 +141,14 @@ class ResponseCacheHandlerTest < MiniTest::Unit::TestCase
     status, content_type, body, timestamp = page
     Cacheable.expects(:decompress).returns(body).once
 
-    @controller.expects(:render).with(text: body, status: status)
+    @controller.expects(:render).with(plain: body, status: status)
     @controller.response.headers.expects(:[]=).with('Content-Type', content_type)
   end
 
   def expect_compressed_page_rendered(page)
     status, content_type, body, timestamp = page
     Cacheable.expects(:decompress).never
-    @controller.expects(:render).with(text: body, status: status)
+    @controller.expects(:render).with(plain: body, status: status)
     @controller.response.headers.expects(:[]=).with('Content-Type', content_type)
     @controller.response.headers.expects(:[]=).with('Content-Encoding', "gzip")
   end


### PR DESCRIPTION
- `render: text` is removed in favor of `render: plain`

Ref shopify/shopify#118807