### PR TITLE
Remove dependency on rails

### DIFF
--- a/cacheable.gemspec
+++ b/cacheable.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "rake"
   s.add_development_dependency "rails", ">= 4.2"
+  s.add_development_dependency "activesupport"
+  s.add_development_dependency "actionpack", ">= 4.1"
 
-  s.add_runtime_dependency "activesupport"
-  s.add_runtime_dependency "actionpack", ">= 4.1"
   s.add_runtime_dependency "useragent"
   s.add_runtime_dependency "msgpack"
 end

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -1,22 +1,24 @@
 require 'cacheable/middleware'
-require 'cacheable/railtie'
+require 'cacheable/railtie' if defined?(Rails)
 require 'cacheable/response_cache_handler'
-require 'cacheable/controller'
 require 'msgpack'
 
 module Cacheable
 
-  def self.cache_store=(store)
-    @cache_store = nil
-    @store=store
+  def self.cache_store=(cache_store)
+    @cache_store = cache_store
   end
 
   def self.cache_store
-    @cache_store ||= ActiveSupport::Cache.lookup_store(*@store || Rails.cache)
+    @cache_store
   end
 
   def self.log(message)
-    Rails.logger.info "[Cacheable] #{message}"
+    @logger.info "[Cacheable] #{message}"
+  end
+
+  def self.logger=(logger)
+    @logger = logger
   end
 
   def self.acquire_lock(cache_key)

--- a/lib/cacheable/middleware.rb
+++ b/lib/cacheable/middleware.rb
@@ -71,7 +71,7 @@ module Cacheable
     ACCEPT = "HTTP_ACCEPT".freeze
     USER_AGENT = "HTTP_USER_AGENT".freeze
     def ie_ajax_request?(env)
-      return false unless env[USER_AGENT].present?
+      return false unless !env[USER_AGENT].nil? && !env[USER_AGENT].empty?
       if env[REQUESTED_WITH] == "XmlHttpRequest".freeze || env[ACCEPT] == "application/json".freeze
         UserAgent.parse(env["HTTP_USER_AGENT"]).is_a?(UserAgent::Browsers::InternetExplorer)
       else

--- a/lib/cacheable/railtie.rb
+++ b/lib/cacheable/railtie.rb
@@ -1,3 +1,5 @@
+require 'cacheable/controller'
+
 module Cacheable
 
   class Railtie < ::Rails::Railtie

--- a/lib/cacheable/version.rb
+++ b/lib/cacheable/version.rb
@@ -1,3 +1,3 @@
 module Cacheable
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -8,7 +8,7 @@ module Rails
   end
 end
 
-Cacheable.cache_store = :memory_store
+Cacheable.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
 
 def app(env)
   body = block_given? ? [yield] : ['Hi']

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require 'mocha/mini_test'
 
 require 'cacheable'
 
+Cacheable.logger = Class.new { def info(a); end }.new
+
 class MockController < ActionController::Base
   def self.after_filter(*args); end
 
@@ -35,7 +37,7 @@ class MockController < ActionController::Base
   end
 
   def logger
-    Class.new { def info(a); end }.new
+    Cacheable.logger
   end
 
   include Cacheable::Controller


### PR DESCRIPTION
This Gem doesn't need to depend on rails, it can be used by rack apps and include a railtie for when it is included in a rails project. 

1. Add a method to set the cacheable logger
2. Allow setting the cache_store directly
3. Make rails controller constructs (e.g. `render`, `head`, `response`) dependent on the presence of rails and confine them to `Cacheable::Controller`.