### PR TITLE
tzinfo-data is needed for testing in some cases

### DIFF
--- a/cacheable.gemspec
+++ b/cacheable.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rails", ">= 4.2"
   s.add_development_dependency "activesupport"
   s.add_development_dependency "actionpack", ">= 4.1"
+  s.add_development_dependency "tzinfo-data", ">= 1.2019.3"
 
   s.add_runtime_dependency "useragent"
   s.add_runtime_dependency "msgpack"


### PR DESCRIPTION
Specifically, TruffleRuby, where I think the JVM means we have a different time zone source to native.