### PR TITLE
Set mtime to avoid fakiness

### DIFF
--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -32,6 +32,7 @@ module Cacheable
   def self.compress(content)
     io = StringIO.new
     gz = Zlib::GzipWriter.new(io)
+    gz.mtime = 1
     gz.write(content)
     io.string
   ensure


### PR DESCRIPTION
Tests such as `test_cache_miss_and_store` rely on GZIP being
deterministic. GZIP file format has a timestamp in its header, which
makes it so that making a GZIP file with the default setting is only
deterministic if done during the same second. Set mtime to 1 instead of
taking the current time in the header. 0 does not work as that indicates
to zlib to take the current time.

No one should be relying on the timestamp in the GZIP header as there
is another timestamp that is encoded in the messagepack payload.