### PR TITLE
Modernize the test suite

### DIFF
--- a/cacheable.gemspec
+++ b/cacheable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_development_dependency "minitest"
+  s.add_development_dependency "minitest", ">= 5.13.0"
   s.add_development_dependency "mocha", ">= 1.10.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rails", ">= 4.2"

--- a/cacheable.gemspec
+++ b/cacheable.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "minitest"
-  s.add_development_dependency "mocha"
+  s.add_development_dependency "mocha", ">= 1.10.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rails", ">= 4.2"
   s.add_development_dependency "activesupport"

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -67,9 +67,9 @@ module Cacheable
     private
     def hash_value_str(data)
       if data.is_a?(Hash)
-          data.values.join(",")
-        else
-          data.to_s
+        data.values.join(",")
+      else
+        data.to_s
       end
     end
   end

--- a/test/cacheable_test.rb
+++ b/test/cacheable_test.rb
@@ -1,6 +1,6 @@
 require File.dirname(__FILE__) + "/test_helper"
 
-class CacheableTest < MiniTest::Unit::TestCase
+class CacheableTest < Minitest::Test
   def setup
     @data = {:foo => 'bar', :bar => [1,['a','b'], 2, {:baz => 'buzz'}], 'qux' => {:red => ['blue', 'green'], :day => true, :night => nil, :updated_at => Time.at(1309362467).utc, :published_on => Time.at(1309320000).utc.to_date}, :format => Mime::Type.lookup('text/html')}
   end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -1,6 +1,6 @@
 require File.dirname(__FILE__) + "/test_helper"
 
-class CacheableControllerTest < MiniTest::Unit::TestCase
+class CacheableControllerTest < Minitest::Test
 
   class MockRequest
     def get?; true ;end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -19,7 +19,7 @@ def not_found(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = true
   env['cacheable.key']   = '"abcd"'
-  
+
   body = block_given? ? [yield] : ['Hi']
   [ 404, {'Content-Type' => 'text/plain'}, body ]
 end
@@ -30,7 +30,6 @@ def cached_moved(env)
   env['cacheable.key']   = '"abcd"'
   env['cacheable.store'] = 'server'
 
-  body = block_given? ? [yield] : ['Hi']
   [ 301, {'Location' => 'http://shopify.com'}, []]
 end
 
@@ -39,55 +38,54 @@ def moved(env)
   env['cacheable.miss']  = true
   env['cacheable.key']   = '"abcd"'
 
-  body = block_given? ? [yield] : ['Hi']
   [ 301, {'Location' => 'http://shopify.com', 'Content-Type' => 'text/plain'}, []]
 end
 
-def cacheable_app(env)  
+def cacheable_app(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = true
   env['cacheable.key']   = '"abcd"'
-  
+
   body = block_given? ? [yield] : ['Hi']
   [ 200, {'Content-Type' => 'text/plain'}, body ]
 end
 
-def already_cached_app(env)  
+def already_cached_app(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = false
   env['cacheable.key']   = '"abcd"'
   env['cacheable.store'] = 'server'
-  
+
   body = block_given? ? [yield] : ['Hi']
   [ 200, {'Content-Type' => 'text/plain'}, body ]
 end
 
-def client_hit_app(env)  
+def client_hit_app(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = false
   env['cacheable.key']   = '"abcd"'
   env['cacheable.store'] = 'client'
-  
+
   body = block_given? ? [yield] : ['']
   [ 304, {'Content-Type' => 'text/plain'}, body ]
 end
 
 class MiddlewareTest < MiniTest::Unit::TestCase
-  
+
   def test_cache_miss_and_ignore
     env = Rack::MockRequest.env_for("http://example.com/index.html")
-    
+
     ware = Cacheable::Middleware.new(method(:app))
     result = ware.call(env)
 
     assert_nil result[1]['ETag']
   end
-      
+
   def test_cache_miss_and_not_found
     Cacheable.cache_store.expects(:write).once()
-    
+
     env = Rack::MockRequest.env_for("http://example.com/index.html")
-    
+
     ware = Cacheable::Middleware.new(method(:not_found))
     result = ware.call(env)
 
@@ -120,9 +118,9 @@ class MiddlewareTest < MiniTest::Unit::TestCase
   def test_cache_miss_and_store
     Cacheable::Middleware.any_instance.stubs(timestamp: 424242)
     Cacheable.cache_store.expects(:write).with('"abcd"', MessagePack.dump([200, 'text/plain', Cacheable.compress('Hi'), 424242]), raw: true).once()
-    
+
     env = Rack::MockRequest.env_for("http://example.com/index.html")
-    
+
     ware = Cacheable::Middleware.new(method(:cacheable_app))
     result = ware.call(env)
 
@@ -134,15 +132,15 @@ class MiddlewareTest < MiniTest::Unit::TestCase
     assert_nil env['cacheable.store']
 
     # no gzip support here
-    assert !result[1]['Content-Encoding']    
+    assert !result[1]['Content-Encoding']
   end
 
   def test_cache_miss_and_store_on_moved
     Cacheable::Middleware.any_instance.stubs(timestamp: 424242)
     Cacheable.cache_store.expects(:write).with('"abcd"', MessagePack.dump([301, 'text/plain', Cacheable.compress(''), 424242, 'http://shopify.com']), raw:true).once()
-    
+
     env = Rack::MockRequest.env_for("http://example.com/index.html")
-    
+
     ware = Cacheable::Middleware.new(method(:moved))
     result = ware.call(env)
 
@@ -154,16 +152,16 @@ class MiddlewareTest < MiniTest::Unit::TestCase
     assert_nil env['cacheable.store']
 
     # no gzip support here
-    assert !result[1]['Content-Encoding']    
+    assert !result[1]['Content-Encoding']
   end
 
   def test_cache_miss_and_store_with_gzip_support
     Cacheable::Middleware.any_instance.stubs(timestamp: 424242)
     Cacheable.cache_store.expects(:write).with('"abcd"', MessagePack.dump([200, 'text/plain', Cacheable.compress('Hi'), 424242]), raw: true).once()
-    
+
     env = Rack::MockRequest.env_for("http://example.com/index.html")
     env['HTTP_ACCEPT_ENCODING'] = 'deflate, gzip'
-    
+
     ware = Cacheable::Middleware.new(method(:cacheable_app))
     result = ware.call(env)
 
@@ -178,12 +176,12 @@ class MiddlewareTest < MiniTest::Unit::TestCase
     assert_equal 'gzip', result[1]['Content-Encoding']
     assert_equal [Cacheable.compress("Hi")], result[2]
   end
-  
+
   def test_cache_hit_server
     Cacheable.cache_store.expects(:write).times(0)
-    
+
     env = Rack::MockRequest.env_for("http://example.com/index.html")
-  
+
     ware = Cacheable::Middleware.new(method(:already_cached_app))
     result = ware.call(env)
 
@@ -192,12 +190,12 @@ class MiddlewareTest < MiniTest::Unit::TestCase
     assert_equal 'server', env['cacheable.store']
     assert_equal '"abcd"', result[1]['ETag']
   end
-  
+
   def test_cache_hit_client
     Cacheable.cache_store.expects(:write).times(0)
-    
+
     env = Rack::MockRequest.env_for("http://example.com/index.html")
-    
+
     ware = Cacheable::Middleware.new(method(:client_hit_app))
     result = ware.call(env)
 

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -1,12 +1,11 @@
 require File.dirname(__FILE__) + "/test_helper"
 
-
-module Rails
-
-  def self.logger
+module EmptyLogger
+  def logger
     @logger ||= Logger.new(nil)
   end
 end
+Rails.singleton_class.prepend(EmptyLogger)
 
 Cacheable.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
 

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -69,7 +69,7 @@ def client_hit_app(env)
   [ 304, {'Content-Type' => 'text/plain'}, body ]
 end
 
-class MiddlewareTest < MiniTest::Unit::TestCase
+class MiddlewareTest < Minitest::Test
 
   def test_cache_miss_and_ignore
     env = Rack::MockRequest.env_for("http://example.com/index.html")

--- a/test/rails_integration_test.rb
+++ b/test/rails_integration_test.rb
@@ -13,7 +13,7 @@ end
 
 Dummy::Application.initialize!
 
-class RailsIntegrationTest < MiniTest::Unit::TestCase
+class RailsIntegrationTest < Minitest::Test
   def test_middleware_is_included
     assert_includes Dummy::Application.middleware, Cacheable::Middleware
   end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + "/test_helper"
 
 ActionController::Base.cache_store = :memory_store
 
-class ResponseCacheHandlerTest < MiniTest::Unit::TestCase
+class ResponseCacheHandlerTest < Minitest::Test
 
   def setup
     @cache_store = stub.tap { |s| s.stubs(read: nil)}

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -136,7 +136,13 @@ class ResponseCacheHandlerTest < MiniTest::Unit::TestCase
     uvkh = handler.unversioned_key_hash
     assert_equal true,  controller.request.env['cacheable.cache']
     assert_equal miss,  controller.request.env['cacheable.miss']
-    assert_equal store, controller.request.env['cacheable.store'] unless store == :anything
+
+    if store.nil?
+      assert_nil controller.request.env['cacheable.store']
+    elsif store != :anything
+      assert_equal store, controller.request.env['cacheable.store']
+    end
+
     assert_equal vkh,   controller.request.env['cacheable.key']
     assert_equal uvkh,  controller.request.env['cacheable.unversioned-key']
   end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -142,14 +142,14 @@ class ResponseCacheHandlerTest < MiniTest::Unit::TestCase
   end
 
   def expect_page_rendered(page)
-    status, content_type, body, timestamp = page
+    _status, content_type, body, _timestamp = page
     Cacheable.expects(:decompress).returns(body).once
 
     @controller.response.headers.expects(:[]=).with('Content-Type', content_type)
   end
 
   def expect_compressed_page_rendered(page)
-    status, content_type, body, timestamp = page
+    _status, content_type, _body, _timestamp = page
     Cacheable.expects(:decompress).never
 
     @controller.response.headers.expects(:[]=).with('Content-Type', content_type)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require 'active_support/cache/memory_store'
 require 'active_support/core_ext/module/deprecation'
 require 'rails'
 require 'action_controller/railtie'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require 'cacheable'
 


### PR DESCRIPTION
Upgrade mocha and minitest and make sure all warnings and deprecations are fixed.

Closes https://github.com/Shopify/cacheable/issues/31