### PR TITLE
Use the ActiveSupport.on_load hooks to include code to Rails classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ This gem supports the following versions of Ruby and Rails:
 
 ### Usage
 
-1. include `Cacheable::Controller` if your controller does not extend `ActionController::Base`
+1. include the gem in your Gemfile
 
 ```ruby
-class PostsController < ActionController::API
-  include Cacheable::Controller
-end 
+gem 'cacheable'
 ```
 
 2. use `#response_cache` method to any desired controller's action

--- a/lib/cacheable/model_extensions.rb
+++ b/lib/cacheable/model_extensions.rb
@@ -1,0 +1,18 @@
+module Cacheable
+  module ModelExtensions
+    def self.included(base)
+      super
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def cache_store
+        ActionController::Base.cache_store
+      end
+    end
+
+    def cache_store
+      ActionController::Base.cache_store
+    end
+  end
+end

--- a/lib/cacheable/railtie.rb
+++ b/lib/cacheable/railtie.rb
@@ -1,20 +1,18 @@
+require 'rails'
 require 'cacheable/controller'
+require 'cacheable/model_extensions'
 
 module Cacheable
-
   class Railtie < ::Rails::Railtie
     initializer "cachable.configure_active_record" do |config|
       config.middleware.insert_after Rack::Head, Cacheable::Middleware
-      ActionController::Base.send(:include, Cacheable::Controller)
 
-      ActiveRecord::Base.class_eval do
-        def self.cache_store
-          ActionController::Base.cache_store
-        end
+      ActiveSupport.on_load(:action_controller) do
+        include Cacheable::Controller
+      end
 
-        def cache_store
-          ActionController::Base.cache_store
-        end
+      ActiveSupport.on_load(:active_record) do
+        include Cacheable::ModelExtensions
       end
     end
   end

--- a/test/rails_integration_test.rb
+++ b/test/rails_integration_test.rb
@@ -8,6 +8,7 @@ end
 
 module ActiveRecord
   class Base
+    ActiveSupport.run_load_hooks(:active_record, self)
   end
 end
 


### PR DESCRIPTION
This will avoid loading the frameworks too early in the boot process.