### PR TITLE
Remove coupling from the side effects of methods

### DIFF
--- a/lib/cacheable/controller.rb
+++ b/lib/cacheable/controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Cacheable
   module Controller
+    private
+
     # Only get? and head? requests should be cacheable
     def cacheable_request?
       request.get? || request.head? && (request.params[:cache] != 'false')

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -3,18 +3,28 @@ require 'digest/md5'
 
 module Cacheable
   class ResponseCacheHandler
-    def initialize(**kwargs, &block)
+    def initialize(
+      key_data:,
+      version_data:,
+      env:,
+      cache_age_tolerance:,
+      serve_unversioned:,
+      headers:,
+      force_refill_cache: false,
+      cache_store: Cacheable.cache_store,
+      &block
+    )
       @cache_miss_block = block
 
-      @key_data = kwargs.fetch(:key_data)
-      @version_data = kwargs.fetch(:version_data)
-      @env = kwargs.fetch(:env)
-      @cache_age_tolerance = kwargs.fetch(:cache_age_tolerance)
+      @key_data = key_data
+      @version_data = version_data
+      @env = env
+      @cache_age_tolerance = cache_age_tolerance
 
-      @serve_unversioned = kwargs[:serve_unversioned]
-      @force_refill_cache = kwargs[:force_refill_cache]
-      @cache_store = kwargs[:cache_store] || Cacheable.cache_store
-      @headers = kwargs[:headers] || {}
+      @serve_unversioned = serve_unversioned
+      @force_refill_cache = force_refill_cache
+      @cache_store = cache_store
+      @headers = headers || {}
     end
 
     def run!

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -26,13 +26,15 @@ module Cacheable
 
       response = try_to_serve_from_cache unless @force_refill_cache
 
-      return response if response
+      if response
+        response
+      else
+        # No cache hit; this request cannot be handled from cache.
+        # Yield to the controller and mark for writing into cache.
+        @env['cacheable.miss'] = true
 
-      # No cache hit; this request cannot be handled from cache.
-      # Yield to the controller and mark for writing into cache.
-      @env['cacheable.miss'] = true
-
-      @cache_miss_block.call
+        @cache_miss_block.call
+      end
     end
 
     def versioned_key_hash

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -24,8 +24,9 @@ module Cacheable
 
       Cacheable.log(cacheable_info_dump)
 
-      try_to_serve_from_cache unless @force_refill_cache
-      return @response if defined?(@response)
+      response = try_to_serve_from_cache unless @force_refill_cache
+
+      return response if response
 
       # No cache hit; this request cannot be handled from cache.
       # Yield to the controller and mark for writing into cache.

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -137,7 +137,7 @@ module Cacheable
 
         status, content_type, body, timestamp, location = hit
 
-        if cache_age_tolerance && page_too_old(timestamp, cache_age_tolerance)
+        if cache_age_tolerance && page_too_old?(timestamp, cache_age_tolerance)
           Cacheable.log("Found an unversioned cache entry, but it was too old (#{timestamp})")
 
           nil
@@ -161,7 +161,7 @@ module Cacheable
       end
     end
 
-    def page_too_old(timestamp, cache_age_tolerance)
+    def page_too_old?(timestamp, cache_age_tolerance)
       !timestamp || timestamp < (Time.now.to_i - cache_age_tolerance)
     end
   end

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -84,9 +84,9 @@ module Cacheable
       return response if response
 
       # execute if we can get the lock
-      execute
+      response = execute
 
-      return if defined?(@response)
+      return response if response
 
       # serve a stale version
       if serving_from_noncurrent_but_recent_version_acceptable?
@@ -102,6 +102,7 @@ module Cacheable
         @env['cacheable.miss'] = true
         Cacheable.log("Refilling cache")
         @response = @cache_miss_block.call
+        @response
       end
     end
 

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -75,13 +75,13 @@ module Cacheable
       return response if response
 
       # Memcached
-      if @serve_unversioned
+      response = if @serve_unversioned
         serve_from_cache(unversioned_key_hash, nil, "Cache hit: server (unversioned)")
       else
         serve_from_cache(versioned_key_hash)
       end
 
-      return if defined?(@response)
+      return response if response
 
       # execute if we can get the lock
       execute
@@ -136,6 +136,7 @@ module Cacheable
 
         if cache_age_tolerance && page_too_old(timestamp, cache_age_tolerance)
           Cacheable.log("Found an unversioned cache entry, but it was too old (#{timestamp})")
+          nil
         else
           @headers['Content-Type'] = content_type
 
@@ -151,6 +152,7 @@ module Cacheable
 
           Cacheable.log(message)
           @response = [status, @headers, [body]]
+          @response
         end
       end
     end

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -31,6 +31,7 @@ module Cacheable
       # No cache hit; this request cannot be handled from cache.
       # Yield to the controller and mark for writing into cache.
       @env['cacheable.miss'] = true
+
       @cache_miss_block.call
     end
 
@@ -102,8 +103,8 @@ module Cacheable
         @env['cacheable.locked'] = true
         @env['cacheable.miss'] = true
         Cacheable.log("Refilling cache")
-        @response = @cache_miss_block.call
-        @response
+
+        @cache_miss_block.call
       end
     end
 
@@ -120,8 +121,8 @@ module Cacheable
         @headers.delete('Content-Length')
 
         Cacheable.log("Cache hit: client")
-        @response = [304, @headers, []]
-        @response
+
+        [304, @headers, []]
       end
     end
 
@@ -138,6 +139,7 @@ module Cacheable
 
         if cache_age_tolerance && page_too_old(timestamp, cache_age_tolerance)
           Cacheable.log("Found an unversioned cache entry, but it was too old (#{timestamp})")
+
           nil
         else
           @headers['Content-Type'] = content_type
@@ -153,8 +155,8 @@ module Cacheable
           end
 
           Cacheable.log(message)
-          @response = [status, @headers, [body]]
-          @response
+
+          [status, @headers, [body]]
         end
       end
     end

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -70,9 +70,9 @@ module Cacheable
 
     def try_to_serve_from_cache
       # Etag
-      serve_from_browser_cache(versioned_key_hash)
+      response = serve_from_browser_cache(versioned_key_hash)
 
-      return if defined?(@response)
+      return response if response
 
       # Memcached
       if @serve_unversioned
@@ -119,6 +119,7 @@ module Cacheable
 
         Cacheable.log("Cache hit: client")
         @response = [304, @headers, []]
+        @response
       end
     end
 

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -90,9 +90,9 @@ module Cacheable
 
       # Memcached
       response = if @serve_unversioned
-        serve_from_cache(unversioned_key_hash, nil, "Cache hit: server (unversioned)")
+        serve_from_cache(unversioned_key_hash, "Cache hit: server (unversioned)")
       else
-        serve_from_cache(versioned_key_hash)
+        serve_from_cache(versioned_key_hash, "Cache hit: server")
       end
 
       return response if response
@@ -104,7 +104,7 @@ module Cacheable
 
       # serve a stale version
       if serving_from_noncurrent_but_recent_version_acceptable?
-        serve_from_cache(unversioned_key_hash, @cache_age_tolerance, "Cache hit: server (recent)")
+        serve_from_cache(unversioned_key_hash, "Cache hit: server (recent)", @cache_age_tolerance)
       end
     end
 
@@ -138,7 +138,7 @@ module Cacheable
       end
     end
 
-    def serve_from_cache(cache_key_hash, cache_age_tolerance = nil, message = "Cache hit: server")
+    def serve_from_cache(cache_key_hash, message, cache_age_tolerance = nil)
       raw = @cache_store.read(cache_key_hash)
 
       if raw

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -50,7 +50,7 @@ class CacheableControllerTest < Minitest::Test
 
   def test_cache_control_no_store_set_for_uncacheable_requests
     controller.expects(:cacheable_request?).returns(false)
-    controller.response_cache {}
+    controller.send(:response_cache) {}
     assert_equal(controller.response.headers['Cache-Control'], 'no-cache, no-store')
   end
 
@@ -59,7 +59,7 @@ class CacheableControllerTest < Minitest::Test
     @cache_store.expects(:read).returns(page_serialized)
     controller.expects(:render).with(plain: '<body>hi.</body>', status: 200)
 
-    controller.response_cache {}
+    controller.send(:response_cache) {}
   end
 
   def test_client_cache_hit
@@ -67,7 +67,7 @@ class CacheableControllerTest < Minitest::Test
     Cacheable::ResponseCacheHandler.any_instance.expects(:versioned_key_hash).returns('deadbeef').at_least_once
     controller.expects(:head).with(:not_modified)
 
-    controller.response_cache {}
+    controller.send(:response_cache) {}
   end
 
   private

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -16,13 +16,13 @@ class ResponseCacheHandlerTest < Minitest::Test
 
   def handler
     @handler = Cacheable::ResponseCacheHandler.new(
-      key_data: controller.cache_key_data,
-      version_data: controller.cache_version_data,
+      key_data: controller.send(:cache_key_data),
+      version_data: controller.send(:cache_version_data),
       cache_store: @cache_store,
       env: controller.request.env,
-      force_refill_cache: controller.force_refill_cache?,
-      serve_unversioned: controller.serve_unversioned_cacheable_entry?,
-      cache_age_tolerance: controller.cache_age_tolerance_in_seconds,
+      force_refill_cache: controller.send(:force_refill_cache?),
+      serve_unversioned: controller.send(:serve_unversioned_cacheable_entry?),
+      cache_age_tolerance: controller.send(:cache_age_tolerance_in_seconds),
       headers: controller.response.headers,
       &proc { [200, {}, 'some text'] }
     )
@@ -113,7 +113,7 @@ class ResponseCacheHandlerTest < Minitest::Test
 
   def test_serve_unversioned_cacheable_entry
     controller.request.env['gzip'] = false
-    assert(@controller.respond_to?(:serve_unversioned_cacheable_entry?))
+    assert(@controller.respond_to?(:serve_unversioned_cacheable_entry?, true))
     @controller.expects(:serve_unversioned_cacheable_entry?).returns(true).times(4)
     @cache_store.expects(:read).with(handler.unversioned_key_hash).returns(page_serialized)
     expect_page_rendered(page_uncompressed)


### PR DESCRIPTION
This class was relying on side effects of private methods to decide what to return. This is confusing and unnecessary, so I just refactored the methods to return values that later are used to decide what to return.