### PR TITLE
Fix cache_miss_block getting called twice:

### DIFF
--- a/lib/cacheable/controller.rb
+++ b/lib/cacheable/controller.rb
@@ -49,6 +49,7 @@ module Cacheable
         serve_unversioned: serve_unversioned_cacheable_entry?,
         force_refill_cache: force_refill_cache?,
         headers: response.headers,
+        controller: self,
         &block
       )
 

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -12,6 +12,7 @@ module Cacheable
       headers:,
       force_refill_cache: false,
       cache_store: Cacheable.cache_store,
+      controller:,
       &block
     )
       @cache_miss_block = block
@@ -25,6 +26,7 @@ module Cacheable
       @force_refill_cache = force_refill_cache
       @cache_store = cache_store
       @headers = headers || {}
+      @controller = controller
     end
 
     def run!
@@ -42,8 +44,7 @@ module Cacheable
         # No cache hit; this request cannot be handled from cache.
         # Yield to the controller and mark for writing into cache.
         @env['cacheable.miss'] = true
-
-        @cache_miss_block.call
+        @controller.response_body || @cache_miss_block.call
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,6 +49,9 @@ class MockController < ActionController::Base
       def headers
         @headers ||= { 'Status' => 200, 'Content-Type' => 'text/html' }
       end
+
+      def reset_body!
+      end
     end.new
   end
 


### PR DESCRIPTION
- If your cache_miss_block returns a falsy value, it would
  result in in being called twice due to this check
  https://github.com/Shopify/cacheable/blob/6626bedf057d4f95c01e0dce57426f39d167ff58/lib/cacheable/response_cache_handler.rb#L46

  This regression was introduced by https://github.com/Shopify/cacheable/pull/36

  Fix is to check whether the block mutated the `response_body`
  before calling the block another time.