### PR TITLE
Don't make use of `controller`:

### DIFF
--- a/lib/cacheable/controller.rb
+++ b/lib/cacheable/controller.rb
@@ -49,7 +49,7 @@ module Cacheable
         serve_unversioned: serve_unversioned_cacheable_entry?,
         force_refill_cache: force_refill_cache?,
         headers: response.headers,
-        controller: self,
+        response: response,
         &block
       )
 

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -12,7 +12,7 @@ module Cacheable
       headers:,
       force_refill_cache: false,
       cache_store: Cacheable.cache_store,
-      controller:,
+      response:,
       &block
     )
       @cache_miss_block = block
@@ -26,7 +26,7 @@ module Cacheable
       @force_refill_cache = force_refill_cache
       @cache_store = cache_store
       @headers = headers || {}
-      @controller = controller
+      @response = response
     end
 
     def run!
@@ -44,7 +44,7 @@ module Cacheable
         # No cache hit; this request cannot be handled from cache.
         # Yield to the controller and mark for writing into cache.
         @env['cacheable.miss'] = true
-        @controller.response_body || @cache_miss_block.call
+        @response.body || @cache_miss_block.call
       end
     end
 

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -24,7 +24,7 @@ class ResponseCacheHandlerTest < Minitest::Test
       serve_unversioned: controller.send(:serve_unversioned_cacheable_entry?),
       cache_age_tolerance: controller.send(:cache_age_tolerance_in_seconds),
       headers: controller.response.headers,
-      controller: controller,
+      response: controller.response,
       &proc { [200, {}, 'some text'] }
     )
   end
@@ -52,7 +52,7 @@ class ResponseCacheHandlerTest < Minitest::Test
       serve_unversioned: controller.send(:serve_unversioned_cacheable_entry?),
       cache_age_tolerance: controller.send(:cache_age_tolerance_in_seconds),
       headers: controller.response.headers,
-      controller: controller,
+      response: controller.response,
       &proc { nil }
     )
 


### PR DESCRIPTION
- Made a mistake in https://github.com/Shopify/cacheable/pull/38 where
  I passed in argument the `controller` but this gem is used by some
  vanilla rack project.

  Passing in the response instead.

  Ref https://github.com/Shopify/cacheable/pull/38#discussion_r367989673
