### PR TITLE
Remove coupling with the controller and but keep running the block only once.

### DIFF
--- a/lib/cacheable/controller.rb
+++ b/lib/cacheable/controller.rb
@@ -49,7 +49,6 @@ module Cacheable
         serve_unversioned: serve_unversioned_cacheable_entry?,
         force_refill_cache: force_refill_cache?,
         headers: response.headers,
-        controller: self,
         &block
       )
 


### PR DESCRIPTION

Before the change on #36, the block was only executed once in case the
lock was acquired but the block returned `nil`. With this change we go
back to that behavior but we don't need to check for the controller or
the response state like it was before #36.

This is an alternative to #38 and #39.

Closes #39.