### PR TITLE
Rename cacheable to response_bank

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in cacheable.gemspec
+# Specify your gem's dependencies in response_bank.gemspec
 gemspec
 
 gem 'rails', '~> 6.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cacheable (2.0.0)
+    response_bank (1.0.0)
       msgpack
       useragent
 
@@ -156,11 +156,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cacheable!
   minitest (>= 5.13.0)
   mocha (>= 1.10.0)
   rails (~> 6.0.0)
   rake
+  response_bank!
   rubocop (= 0.78.0)
   tzinfo-data (>= 1.2019.3)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cacheable [![Build Status](https://secure.travis-ci.org/Shopify/cacheable.png)](http://travis-ci.org/Shopify/cacheable)
+# ResponseBank [![Build Status](https://secure.travis-ci.org/Shopify/response_bank.png)](http://travis-ci.org/Shopify/response_bank)
 
 ### Features
 
@@ -19,7 +19,7 @@ This gem supports the following versions of Ruby and Rails:
 1. include the gem in your Gemfile
 
 ```ruby
-gem 'cacheable'
+gem 'response_bank'
 ```
 
 2. use `#response_cache` method to any desired controller's action
@@ -83,9 +83,9 @@ class PostsController < ApplicationController
   def set_shop
     # @shop = ...
   end
-end 
+end
 ```
 
 ### License
 
-Cacheable is released under the [MIT License](LICENSE.txt).
+ResponseBank is released under the [MIT License](LICENSE.txt).

--- a/lib/cacheable/version.rb
+++ b/lib/cacheable/version.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-module Cacheable
-  VERSION = "2.0.0"
-end

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
-require 'cacheable/middleware'
-require 'cacheable/railtie' if defined?(Rails)
-require 'cacheable/response_cache_handler'
+require 'response_bank/middleware'
+require 'response_bank/railtie' if defined?(Rails)
+require 'response_bank/response_cache_handler'
 require 'msgpack'
 
-module Cacheable
+module ResponseBank
   class << self
     attr_accessor :cache_store
     attr_writer :logger
 
     def log(message)
-      @logger.info("[Cacheable] #{message}")
+      @logger.info("[ResponseBank] #{message}")
     end
 
     def acquire_lock(_cache_key)
-      raise NotImplementedError, "Override Cacheable.acquire_lock in an initializer."
+      raise NotImplementedError, "Override ResponseBank.acquire_lock in an initializer."
     end
 
     def write_to_cache(_key)

--- a/lib/response_bank/controller.rb
+++ b/lib/response_bank/controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-module Cacheable
+module ResponseBank
   module Controller
     private
 
-    # Only get? and head? requests should be cacheable
+    # Only get? and head? requests should be cached.
     def cacheable_request?
       (request.get? || request.head?) && (request.params[:cache] != 'false')
     end
@@ -35,13 +35,13 @@ module Cacheable
       cacheable_req = cacheable_request?
 
       unless cache_configured? && cacheable_req
-        Cacheable.log("Uncacheable request. cache_configured='#{!!cache_configured?}'" \
+        ResponseBank.log("Uncacheable request. cache_configured='#{!!cache_configured?}'" \
             " cacheable_request='#{cacheable_req}' params_cache='#{request.params[:cache] != 'false'}'")
         response.headers['Cache-Control'] = 'no-cache, no-store' unless cacheable_req
         return yield
       end
 
-      handler = Cacheable::ResponseCacheHandler.new(
+      handler = ResponseBank::ResponseCacheHandler.new(
         key_data: key_data || cache_key_data,
         version_data: version_data || cache_version_data,
         env: request.env,

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'useragent'
 
-module Cacheable
+module ResponseBank
   class Middleware
     REQUESTED_WITH = "HTTP_X_REQUESTED_WITH"
     ACCEPT = "HTTP_ACCEPT"
@@ -36,18 +36,18 @@ module Cacheable
             body.each { |part| body_string << part }
           end
 
-          body_gz = Cacheable.compress(body_string)
+          body_gz = ResponseBank.compress(body_string)
 
           # Store result
           cache_data = [status, headers['Content-Type'], body_gz, timestamp]
           cache_data << headers['Location'] if status == 301
 
-          Cacheable.write_to_cache(env['cacheable.key']) do
+          ResponseBank.write_to_cache(env['cacheable.key']) do
             payload = MessagePack.dump(cache_data)
-            Cacheable.cache_store.write(env['cacheable.key'], payload, raw: true)
+            ResponseBank.cache_store.write(env['cacheable.key'], payload, raw: true)
 
             if env['cacheable.unversioned-key']
-              Cacheable.cache_store.write(env['cacheable.unversioned-key'], payload, raw: true)
+              ResponseBank.cache_store.write(env['cacheable.unversioned-key'], payload, raw: true)
             end
           end
 

--- a/lib/response_bank/model_extensions.rb
+++ b/lib/response_bank/model_extensions.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-module Cacheable
+module ResponseBank
   module ModelExtensions
     def self.included(base)
       super

--- a/lib/response_bank/railtie.rb
+++ b/lib/response_bank/railtie.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 require 'rails'
-require 'cacheable/controller'
-require 'cacheable/model_extensions'
+require 'response_bank/controller'
+require 'response_bank/model_extensions'
 
-module Cacheable
+module ResponseBank
   class Railtie < ::Rails::Railtie
     initializer "cachable.configure_active_record" do |config|
-      config.middleware.insert_after(Rack::Head, Cacheable::Middleware)
+      config.middleware.insert_after(Rack::Head, ResponseBank::Middleware)
 
       ActiveSupport.on_load(:action_controller) do
-        include Cacheable::Controller
+        include ResponseBank::Controller
       end
 
       ActiveSupport.on_load(:active_record) do
-        include Cacheable::ModelExtensions
+        include ResponseBank::ModelExtensions
       end
     end
   end

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+module ResponseBank
+  VERSION = "1.0.0"
+end

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -1,17 +1,16 @@
 # -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 $LOAD_PATH.push(File.expand_path("../lib", __FILE__))
-require "cacheable/version"
+require "response_bank/version"
 
 Gem::Specification.new do |s|
-  s.name        = "cacheable"
-  s.version     = Cacheable::VERSION
+  s.name        = "response_bank"
+  s.version     = ResponseBank::VERSION
   s.license     = "MIT"
   s.authors     = ["Tobias Lütke", "Burke Libbey"]
   s.email       = ["tobi@shopify.com", "burke@burkelibbey.org"]
   s.homepage    = ""
-  s.summary     = 'Simple rails request caching'
-  s.description = 'Simple rails request caching'
+  s.summary     = 'Simple response caching for Ruby applications'
 
   s.files         = Dir["lib/**/*.rb", "README.md", "LICENSE.txt"]
   s.require_paths = ["lib"]

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/test_helper"
 
-class CacheableControllerTest < Minitest::Test
+class ResponseBankControllerTest < Minitest::Test
   class MockRequest
     def get?
       true
@@ -23,7 +23,7 @@ class CacheableControllerTest < Minitest::Test
   end
 
   class MockController
-    include Cacheable::Controller
+    include ResponseBank::Controller
 
     def cache_configured?
       true
@@ -44,8 +44,8 @@ class CacheableControllerTest < Minitest::Test
 
   def setup
     @cache_store = stub.tap { |s| s.stubs(read: nil) }
-    Cacheable.cache_store = @cache_store
-    Cacheable.stubs(:acquire_lock).returns(true)
+    ResponseBank.cache_store = @cache_store
+    ResponseBank.stubs(:acquire_lock).returns(true)
   end
 
   def test_cache_control_no_store_set_for_uncacheable_requests
@@ -64,7 +64,7 @@ class CacheableControllerTest < Minitest::Test
 
   def test_client_cache_hit
     controller.request.env['HTTP_IF_NONE_MATCH'] = 'deadbeef'
-    Cacheable::ResponseCacheHandler.any_instance.expects(:versioned_key_hash).returns('deadbeef').at_least_once
+    ResponseBank::ResponseCacheHandler.any_instance.expects(:versioned_key_hash).returns('deadbeef').at_least_once
     controller.expects(:head).with(:not_modified)
 
     controller.send(:response_cache) {}
@@ -77,6 +77,6 @@ class CacheableControllerTest < Minitest::Test
   end
 
   def page_serialized
-    MessagePack.dump([200, "text/html", Cacheable.compress("<body>hi.</body>"), 1331765506])
+    MessagePack.dump([200, "text/html", ResponseBank.compress("<body>hi.</body>"), 1331765506])
   end
 end

--- a/test/rails_integration_test.rb
+++ b/test/rails_integration_test.rb
@@ -17,7 +17,7 @@ Dummy::Application.initialize!
 
 class RailsIntegrationTest < Minitest::Test
   def test_middleware_is_included
-    assert_includes(Dummy::Application.middleware, Cacheable::Middleware)
+    assert_includes(Dummy::Application.middleware, ResponseBank::Middleware)
   end
 
   def test_active_record_has_a_cache_store
@@ -26,6 +26,6 @@ class RailsIntegrationTest < Minitest::Test
   end
 
   def test_action_controller_includes_cacheable
-    assert_includes(ActionController::Base, Cacheable::Controller)
+    assert_includes(ActionController::Base, ResponseBank::Controller)
   end
 end

--- a/test/response_bank_test.rb
+++ b/test/response_bank_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/test_helper"
 
-class CacheableTest < Minitest::Test
+class ResponseBankTest < Minitest::Test
   def setup
     @data = {
       :foo => 'bar',
@@ -19,17 +19,17 @@ class CacheableTest < Minitest::Test
 
   def test_cache_key_for_handles_nested_everything_and_removes_hash_keys_with_nil_values
     expected = %|bar,1,a,b,2,{:baz=>\"buzz\"},{:red=>[\"blue\", \"green\"], :day=>true, :night=>nil, :updated_at=>2011-06-29 15:47:47 UTC, :published_on=>Wed, 29 Jun 2011},text/html| # rubocop:disable Metrics/LineLength
-    assert_equal(expected, Cacheable.cache_key_for(key: @data))
+    assert_equal(expected, ResponseBank.cache_key_for(key: @data))
   end
 
   def test_cache_key_with_no_key_key
     expected = %|{:foo=>\"bar\", :bar=>[1, [\"a\", \"b\"], 2, {:baz=>\"buzz\"}], \"qux\"=>{:red=>[\"blue\", \"green\"], :day=>true, :night=>nil, :updated_at=>2011-06-29 15:47:47 UTC, :published_on=>Wed, 29 Jun 2011}}| # rubocop:disable Metrics/LineLength
-    assert_equal(expected, Cacheable.cache_key_for(@data.tap { |h| h.delete(:format) }))
+    assert_equal(expected, ResponseBank.cache_key_for(@data.tap { |h| h.delete(:format) }))
   end
 
   def test_cache_key_with_key_and_version
     version = { version: 42 }
     expected = %|bar,1,a,b,2,{:baz=>\"buzz\"},{:red=>[\"blue\", \"green\"], :day=>true, :night=>nil, :updated_at=>2011-06-29 15:47:47 UTC, :published_on=>Wed, 29 Jun 2011},text/html:42| # rubocop:disable Metrics/LineLength
-    assert_equal(expected, Cacheable.cache_key_for(key: @data, version: version))
+    assert_equal(expected, ResponseBank.cache_key_for(key: @data, version: version))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,9 @@ require 'rails'
 require 'action_controller/railtie'
 require 'mocha/minitest'
 
-require 'cacheable'
+require 'response_bank'
 
-Cacheable.logger = Class.new { def info(a); end }.new
+ResponseBank.logger = Class.new { def info(a); end }.new
 
 class MockController < ActionController::Base
   def self.after_filter(*args); end
@@ -56,17 +56,17 @@ class MockController < ActionController::Base
   end
 
   def logger
-    Cacheable.logger
+    ResponseBank.logger
   end
 
-  include Cacheable::Controller
+  include ResponseBank::Controller
 
   def cacheable?
     true
   end
 end
 
-class << Cacheable
+class << ResponseBank
   module ScrubGzipTimestamp
     def compress(*)
       gzip_content = super
@@ -81,4 +81,4 @@ class << Cacheable
 end
 
 $LOAD_PATH << File.expand_path('../lib', __FILE__)
-require 'cacheable'
+require 'response_bank'


### PR DESCRIPTION
[The cacheable gem is already taken on Rubygems](https://rubygems.org/gems/cacheable), so we had to find a different name for this library.